### PR TITLE
Hack to make sure all points get displayed for a given person

### DIFF
--- a/scripts/functions.js
+++ b/scripts/functions.js
@@ -21,7 +21,8 @@ function filterByPerson(placesList, select) {
 		map.setFilter('places-layer', null);
 		select.selectedIndex = 0;
 	} else {
-		const placeIDs = placesList.split(',');
+		// ugly hack here: sometimes the Mapbox filter seems to ignore the first item in the array, so by prepending a null value we can make sure all the real values get included
+		const placeIDs = ('-1,' + placesList).split(',');
 		let filter = null;
 		if (placeIDs.length > 1) {
 			filter = [


### PR DESCRIPTION
In investigating the Ted & Ruth Peterson issue listed at https://github.com/eldang/ballard-4culture/issues/15 I learned that this in fact affects many people; maybe all of the people with > 2 associated places.  I don't entirely understand what's going wrong here, but it looks like the Mapbox filter we set to show specific places sometimes ignores the first ID in the list.  So I worked around it by prepending an ID that's guaranteed not to match any places.

I've stepped through the people dropdown and verified that after this change every person gets the same number of points visible on the map as place IDs in their `people.json` record.  So if there are any other discrepancies then the error must be further upstream, in the generation of that file.