### PR TITLE
Add missing audio file

### DIFF
--- a/mp3/25_Metcalf_Veida_audio.mp3
+++ b/mp3/25_Metcalf_Veida_audio.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5e4de8091d6c0aa2a4bff220c34782cd1261d1862a25dfc4f9d94518f4af044
+size 51657145


### PR DESCRIPTION
BHS noticed the link to mp3 audio for Veida Metcalf was not working, turns out we were missing the file! @eldang will you please upload this to BHS subdomain when you have a chance?

![image](https://user-images.githubusercontent.com/8813214/153951203-6ca0ffc9-d292-41c4-ab37-39d7ec377506.png)
